### PR TITLE
Fix: Update broken image link

### DIFF
--- a/next.js-apps/next.js-start/src/app/page.tsx
+++ b/next.js-apps/next.js-start/src/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <main className="min-h-dvh w-screen flex items-center justify-center flex-col gap-y-4 p-4">
       <img
         className="max-w-sm w-full"
-        src="https://tanstack.com/assets/splash-dark-8nwlc0Nt.png"
+        src="https://raw.githubusercontent.com/TanStack/tanstack.com/main/public/images/logos/splash-dark.png"
         alt="TanStack Logo"
       />
       <h1>


### PR DESCRIPTION
The image link https://tanstack.com/assets/splash-dark-8nwlc0Nt.png is broken.
So, updating the link to a valid image as used here: [Migrate from Next.js](https://tanstack.com/start/latest/docs/framework/react/migrate-from-next-js)

The above link is chosen mainly because it's already used in the above migration doc.  
However, another option could be to use this image link `https://tanstack.com/images/logos/splash-dark.png` as suggested in the [TanStack Brand Guide](https://tanstack.com/brand-guide)